### PR TITLE
Fix: use Buffer.from instead of new Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@
         if (Buffer.alloc) {
             buf = Buffer.alloc(size);
         } else {
-            buf = new Buffer(size);
+            buf = Buffer.from(size);
             buf.fill(0);
         }
         return buf;
@@ -45,7 +45,7 @@
         if (Buffer.from) {
             buf = Buffer.from(object);
         } else {
-            buf = new Buffer(object);
+            buf = Buffer.from(object);
         }
         return buf;
     }


### PR DESCRIPTION
`new Buffer(...)` is a deprecated function in Node.js since v6.0 and most libraries now uses `Buffer.from(...)` instead. Since of a deprecated function, `new Buffer(...)` will emit an warning when the library in use.

Deprecation note: https://nodejs.org/api/buffer.html#new-bufferarray